### PR TITLE
Update platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -36,6 +36,7 @@
 
 [env:NUCLEO-F103RB]
 platform = ststm32
+board_build.core = maple
 board = genericSTM32F103RB
 framework = arduino
 build_flags = -D USE_HSI_CLOCK


### PR DESCRIPTION
Add maple back in for libmaple dependencies, which are removed in current version of ststm32